### PR TITLE
one of other tests hangs on Windows if AnyEvent::Ping is not present

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -20,6 +20,8 @@ skip = ^MooX::Types::MooseLike::Base$
 
 [Test::Compile]
 skip = ^Juno::Check::.+$
+bail_out_on_fail = 1
+:version=2.039
 
 [MetaResources]
 repository = http://github.com/xsawyerx/juno


### PR DESCRIPTION
version requirement is to prevent hanging of 00-compile.t itself
